### PR TITLE
php 8 compatibility

### DIFF
--- a/core/class/edf_tempo.class.php
+++ b/core/class/edf_tempo.class.php
@@ -375,6 +375,8 @@ class edf_tempo extends eqLogic {
           $couleurJourJ1 = $item['statut'];
       }
     }
+	
+	$r = new stdClass();
     $r->couleurJourJ  = $couleurJourJ;
     $r->couleurJourJ1 = $couleurJourJ1;
 
@@ -394,6 +396,7 @@ class edf_tempo extends eqLogic {
       return $restant;
     }
     
+	$r = new stdClass();
     foreach ($restant['content'] as $item) {
         $typeJourEff = $item['typeJourEff'];
         if (!isset($sortedData[$typeJourEff])) {


### PR DESCRIPTION
Prevent bug on PHP8 when trying to refresh 

`PHP Fatal error:  Uncaught Error: Attempt to assign property "couleurJourJ" on null in /var/www/html/plugins/edf_tempo/core/class/edf_tempo.class.php:378`

`PHP Fatal error:  Uncaught Error: Attempt to assign property "PARAM_NB_J_ROUGE" on null in /var/www/html/plugins/edf_tempo/core/class/edf_tempo.class.php:415`